### PR TITLE
Prepend a leading slash to the matcher if the path has one

### DIFF
--- a/Example/Tests/RouterTests.swift
+++ b/Example/Tests/RouterTests.swift
@@ -153,6 +153,12 @@ final class RouterPathTypeMatchingTests: RouterTest {
 
         XCTAssertIsNotFoundView(router.view("hi/world"))
     }
+
+    func testRouter_shouldMatchPathWithLeadingSlash() {
+        router.add(path: "/a/path") { EmptyView() }
+
+        XCTAssertFoundView(router.view("/a/path"))
+    }
 }
 
 // swiftlint:disable line_length

--- a/SwiftTypedRouter/Classes/Router.swift
+++ b/SwiftTypedRouter/Classes/Router.swift
@@ -66,7 +66,7 @@ public class Router: CustomStringConvertible {
     }
 
     public var description: String {
-        self.identifier.map { "Router(\($0))" } ?? "Router"
+        self.identifier.map { "Router(\($0))" } ?? "Router()"
     }
 }
 

--- a/SwiftTypedRouter/Classes/Template.swift
+++ b/SwiftTypedRouter/Classes/Template.swift
@@ -24,6 +24,9 @@ public class Template {
     private static func createMatcherExpression(path: String, types: [Any.Type]) -> NSRegularExpression? {
         var types = types
 
+        // We need to prepend a leading slash if there is one in the original path
+        let hasLeadingPath = path.hasPrefix("/")
+
         let comps = path
             .split(separator: "/")
             .map { (component: Substring) -> Substring in
@@ -35,8 +38,14 @@ public class Template {
                 return "(" + match + ")"
         }
 
+        // Rejoin them
+        var substitutedPath = comps.joined(separator: "/")
+        if hasLeadingPath {
+            substitutedPath = "/" + substitutedPath
+        }
+
         do {
-            let expression = try NSRegularExpression(pattern: "^" + comps.joined(separator: "/"),
+            let expression = try NSRegularExpression(pattern: "^" + substitutedPath,
                                                      options: [ .caseInsensitive ])
             print("Generated expression \(expression.pattern) from \(path)")
             return expression


### PR DESCRIPTION
Hey @kerrmarin :)

Fixes #18 - start with the test to make sure that I've understood the issue.

The culprit was the `.split("/")` in `Template.swift:31` which I'd assumed would return an empty string if it starts with a "/" - turns out it doesn't, it just silently drops it.